### PR TITLE
Flipped edge cases for perfect alignment and anti-alignment

### DIFF
--- a/watson_dist/watson_distribution.py
+++ b/watson_dist/watson_distribution.py
@@ -118,8 +118,8 @@ class DimrothWatson(rv_continuous):
 
         # deal with the edge cases
         epsilon = np.finfo(float).eps
-        #edge_mask = (p >= 1.0/epsilon) | (p == 0.0)
-        edge_mask = (p >= 1.0/epsilon)
+        edge_mask = (p >= 1.0/epsilon) | (p == 0.0)
+        #edge_mask = (p >= 1.0/epsilon)
         p[edge_mask] = 0.0
 
         # large negative k (bipolar)

--- a/watson_dist/watson_distribution.py
+++ b/watson_dist/watson_distribution.py
@@ -187,7 +187,7 @@ class DimrothWatson(rv_continuous):
         edge_mask = ((x == np.inf) | (x == 0.0))
         #result[edge_mask & (k>0)] = np.random.choice([1,-1], size=np.sum(edge_mask & (k>0)))
         #result[edge_mask & (k<0)] = 0.0
-        result[edge_mask & (k<0)] = np.random.choice([1,-1], size=np.sum(edge_mask & (k>0)))
+        result[edge_mask & (k<0)] = np.random.choice([1,-1], size=np.sum(edge_mask & (k<0)))
         result[edge_mask & (k>0)] = 0.0
 
         # apply rejection sampling technique to sample from pdf

--- a/watson_dist/watson_distribution.py
+++ b/watson_dist/watson_distribution.py
@@ -185,10 +185,10 @@ class DimrothWatson(rv_continuous):
             x = np.exp(k)
             inf_mask = np.array([False]*size)
         edge_mask = ((x == np.inf) | (x == 0.0))
-        #result[edge_mask & (k>0)] = np.random.choice([1,-1], size=np.sum(edge_mask & (k>0)))
-        #result[edge_mask & (k<0)] = 0.0
-        result[edge_mask & (k<0)] = np.random.choice([1,-1], size=np.sum(edge_mask & (k<0)))
-        result[edge_mask & (k>0)] = 0.0
+        result[edge_mask & (k>0)] = np.random.choice([1,-1], size=np.sum(edge_mask & (k>0)))
+        result[edge_mask & (k<0)] = 0.0
+        #result[edge_mask & (k<0)] = np.random.choice([1,-1], size=np.sum(edge_mask & (k<0)))
+        #result[edge_mask & (k>0)] = 0.0
 
         # apply rejection sampling technique to sample from pdf
         n_sucess = np.sum(zero_k) + np.sum(edge_mask)  # number of sucesessful draws from pdf

--- a/watson_dist/watson_distribution.py
+++ b/watson_dist/watson_distribution.py
@@ -117,7 +117,7 @@ class DimrothWatson(rv_continuous):
             p = np.nan_to_num(p)
 
         # deal with the edge cases
-        epsilon = 10.0*np.finfo(float).eps
+        epsilon = 1e-5
         edge_mask = (p >= 1.0/epsilon) | (p == 0.0)
         #edge_mask = (p >= 1.0/epsilon)
         p[edge_mask] = 0.0

--- a/watson_dist/watson_distribution.py
+++ b/watson_dist/watson_distribution.py
@@ -118,7 +118,8 @@ class DimrothWatson(rv_continuous):
 
         # deal with the edge cases
         epsilon = np.finfo(float).eps
-        edge_mask = (p >= 1.0/epsilon) | (p == 0.0)
+        #edge_mask = (p >= 1.0/epsilon) | (p == 0.0)
+        edge_mask = (p >= 1.0/epsilon)
         p[edge_mask] = 0.0
 
         # large positive k (bipolar)

--- a/watson_dist/watson_distribution.py
+++ b/watson_dist/watson_distribution.py
@@ -122,13 +122,15 @@ class DimrothWatson(rv_continuous):
         edge_mask = (p >= 1.0/epsilon)
         p[edge_mask] = 0.0
 
-        # large positive k (bipolar)
+        # large negative k (bipolar)
         bipolar = (x >= (1.0 - epsilon)) | (x <= (-1.0 + epsilon))
-        p[bipolar & edge_mask & (k>1)] = 1.0/(2.0*epsilon)
+        #p[bipolar & edge_mask & (k>1)] = 1.0/(2.0*epsilon)
+        p[bipolar & edge_mask & (k < -1)] = 1.0/(2.0*epsilon)
 
-        # large negative k (girdle)
+        # large positive k (girdle)
         girdle = (x >= (0.0 - epsilon)) & (x <= (0.0 + epsilon))
-        p[girdle & edge_mask & (k <- 1)] = 1.0/(2.0*epsilon)
+        #p[girdle & edge_mask & (k <- 1)] = 1.0/(2.0*epsilon)
+        p[girdle & edge_mask & (k > 1)] = 1.0/(2.0*epsilon)
 
         return p
 

--- a/watson_dist/watson_distribution.py
+++ b/watson_dist/watson_distribution.py
@@ -185,8 +185,10 @@ class DimrothWatson(rv_continuous):
             x = np.exp(k)
             inf_mask = np.array([False]*size)
         edge_mask = ((x == np.inf) | (x == 0.0))
-        result[edge_mask & (k>0)] = np.random.choice([1,-1], size=np.sum(edge_mask & (k>0)))
-        result[edge_mask & (k<0)] = 0.0
+        #result[edge_mask & (k>0)] = np.random.choice([1,-1], size=np.sum(edge_mask & (k>0)))
+        #result[edge_mask & (k<0)] = 0.0
+        result[edge_mask & (k<0)] = np.random.choice([1,-1], size=np.sum(edge_mask & (k>0)))
+        result[edge_mask & (k>0)] = 0.0
 
         # apply rejection sampling technique to sample from pdf
         n_sucess = np.sum(zero_k) + np.sum(edge_mask)  # number of sucesessful draws from pdf

--- a/watson_dist/watson_distribution.py
+++ b/watson_dist/watson_distribution.py
@@ -185,10 +185,10 @@ class DimrothWatson(rv_continuous):
             x = np.exp(k)
             inf_mask = np.array([False]*size)
         edge_mask = ((x == np.inf) | (x == 0.0))
-        result[edge_mask & (k>0)] = np.random.choice([1,-1], size=np.sum(edge_mask & (k>0)))
-        result[edge_mask & (k<0)] = 0.0
-        #result[edge_mask & (k<0)] = np.random.choice([1,-1], size=np.sum(edge_mask & (k<0)))
-        #result[edge_mask & (k>0)] = 0.0
+        #result[edge_mask & (k>0)] = np.random.choice([1,-1], size=np.sum(edge_mask & (k>0)))
+        #result[edge_mask & (k<0)] = 0.0
+        result[edge_mask & (k<0)] = np.random.choice([1,-1], size=np.sum(edge_mask & (k<0)))
+        result[edge_mask & (k>0)] = 0.0
 
         # apply rejection sampling technique to sample from pdf
         n_sucess = np.sum(zero_k) + np.sum(edge_mask)  # number of sucesessful draws from pdf

--- a/watson_dist/watson_distribution.py
+++ b/watson_dist/watson_distribution.py
@@ -117,7 +117,7 @@ class DimrothWatson(rv_continuous):
             p = np.nan_to_num(p)
 
         # deal with the edge cases
-        epsilon = np.finfo(float).eps
+        epsilon = 10.0*np.finfo(float).eps
         edge_mask = (p >= 1.0/epsilon) | (p == 0.0)
         #edge_mask = (p >= 1.0/epsilon)
         p[edge_mask] = 0.0


### PR DESCRIPTION
Apologies for the format of below. I just copied and pasted the notes I took for myself while working on this to convince myself I made a proper change.

- In the Dimroth Watson class, k exists on (-inf, inf) while p exists on [-1,1]
    - alignment strength takes the value of p on [-1,1] and maps to k on (-inf,inf)
    - p = 1 corresponds to perfect alignment ( cos(theta) = -1,1 )
    - p = -1 corresponds to perfect anti-alignment ( cos(theta) = 0 )
    - With my change, the following happens:
        - in pdf:
            - at exactly k = alignment_strength(p=1), we get deltas at cos(theta) = -1,1
            - at exactly k = alignment_strength(p=-1), it goes flat at 0 (?)
                - Before my change, these behaviors were flipped
            - Values just before alignment_strength(p= 1,-1) work as expected in both
        - in rvs:
            - at exactly k = alignment_strength(p=1), rvs randomly returns either a 1 or -1
            - at exactly k = alignment_strength(p=-1), rvs returns 0